### PR TITLE
Fix bee-proof on Big Sur

### DIFF
--- a/lib/bee-proof.rb
+++ b/lib/bee-proof.rb
@@ -30,7 +30,7 @@ module BeeProof
   def self.run_for_release(emr_release, *params)
     cmd = 
         [
-            java_bin_path,
+            "'#{java_bin_path}'",
             '-Dfile.encoding=UTF-8',
             '-classpath',
             [ 


### PR DESCRIPTION
Big Sur is breaking for JAVA_HOME values w/ a space in it.  Quoting the path fixes this.